### PR TITLE
Fix Minikube communication issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ eval $(minikube docker-env)
 # Backend API image
 docker build -t thesis-backend:latest ./thesis-backend-starter
 
-# Frontend React image
-docker build -t thesis-frontend:latest ./thesis_frontend_prototype
+# Frontend React image (πέρασμα του API URL στο build)
+docker build \
+  --build-arg REACT_APP_API_BASE_URL=http://thesis-backend-service:8080/api \
+  -t thesis-frontend:latest ./thesis_frontend_prototype
 ```
 
 ### 7. Deployment στο Minikube

--- a/thesis-backend-starter/src/main/java/com/thesis/backend/config/CorsConfig.java
+++ b/thesis-backend-starter/src/main/java/com/thesis/backend/config/CorsConfig.java
@@ -15,8 +15,8 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         
-        // Allow requests from the React development server
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "http://127.0.0.1:3000"));
+        // Allow requests from any origin (useful for Minikube NodePorts)
+        configuration.addAllowedOriginPattern("*");
         
         // Allow common HTTP methods
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));

--- a/thesis_frontend_prototype/Dockerfile
+++ b/thesis_frontend_prototype/Dockerfile
@@ -4,12 +4,11 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-ARG REACT_APP_API_BASE_URL=http://localhost:8080/api
+ARG REACT_APP_API_BASE_URL=http://thesis-backend-service:8080/api
 ENV REACT_APP_API_BASE_URL=${REACT_APP_API_BASE_URL}
 RUN npm run build
 
 # Production stage
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 80CMD ["nginx", "-g", "daemon off;"]

--- a/thesis_frontend_prototype/k8s-deployment.yaml
+++ b/thesis_frontend_prototype/k8s-deployment.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: frontend-config
-data:
-  REACT_APP_API_BASE_URL: http://thesis-backend-service:8080/api
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,12 +16,6 @@ spec:
         - name: thesis-frontend
           image: thesis-frontend:latest
           imagePullPolicy: Never
-          env:
-            - name: REACT_APP_API_BASE_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: frontend-config
-                  key: REACT_APP_API_BASE_URL
           ports:
             - containerPort: 80
 ---
@@ -44,4 +31,3 @@ spec:
     - port: 80
       targetPort: 80
       nodePort: 30008
-      


### PR DESCRIPTION
## Summary
- build the React image with the backend URL baked in
- relax backend CORS to allow all origins
- drop unused ConfigMap from frontend deployment
- clean up frontend Dockerfile

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd298134483249c079264d947d6c4