### PR TITLE
Fix Dockerfile newline

### DIFF
--- a/thesis_frontend_prototype/Dockerfile
+++ b/thesis_frontend_prototype/Dockerfile
@@ -11,4 +11,6 @@ RUN npm run build
 # Production stage
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 80CMD ["nginx", "-g", "daemon off;"]
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- ensure final Dockerfile instructions are separated by newlines

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d9996cd3083248f65a2b59531052c