### PR TITLE
Fix dockerignore name

### DIFF
--- a/thesis_frontend_prototype/.dockerignore
+++ b/thesis_frontend_prototype/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/thesis_frontend_prototype/.dockeringore
+++ b/thesis_frontend_prototype/.dockeringore
@@ -1,1 +1,0 @@
-node_modules


### PR DESCRIPTION
## Summary
- rename `.dockeringore` to `.dockerignore` in the frontend prototype
- keep `node_modules` entry with a trailing newline

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d9a950af88324a1f5b6e616c1be69