### PR TITLE
fix: move openssl legacy setting to env file

### DIFF
--- a/thesis_frontend_prototype/.env
+++ b/thesis_frontend_prototype/.env
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--openssl-legacy-provider

--- a/thesis_frontend_prototype/package.json
+++ b/thesis_frontend_prototype/package.json
@@ -20,8 +20,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts --openssl-legacy-provider build",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
- remove `--openssl-legacy-provider` from npm scripts
- set `NODE_OPTIONS=--openssl-legacy-provider` via `.env`

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6895c72b32dc8324a28b0a09b67bd013