### PR TITLE
chore: remove scripts dependency

### DIFF
--- a/thesis_frontend_prototype/package-lock.json
+++ b/thesis_frontend_prototype/package-lock.json
@@ -21,7 +21,6 @@
         "react-router-dom": "^6.23.0",
         "react-scripts": "^5.0.1",
         "react-toastify": "^11.0.5",
-        "scripts": "^0.1.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -16484,14 +16483,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/scripts": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/scripts/-/scripts-0.1.0.tgz",
-      "integrity": "sha512-URMy4uj80+USxik0E+P7OeagdYGRM6vJQ+8zADRRNjcoIVdouxB7B60P4G4y20TizSGXdE0nAW5sSM1IIXa3hw==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/select-hose": {
       "version": "2.0.0",

--- a/thesis_frontend_prototype/package.json
+++ b/thesis_frontend_prototype/package.json
@@ -16,7 +16,6 @@
     "react-router-dom": "^6.23.0",
     "react-scripts": "^5.0.1",
     "react-toastify": "^11.0.5",
-    "scripts": "^0.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- remove deprecated `scripts` package from frontend dependencies
- update lockfile

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false` (fails: Unable to find element with the text /learn react/i)


------
https://chatgpt.com/codex/tasks/task_e_6895c7ef0c948324a97f405301ebaedf